### PR TITLE
🐛 Fix: 버그 수정(비 로그인 조회 안되는 버그 수정)(#85)

### DIFF
--- a/src/main/kotlin/com/eatsfinder/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/eatsfinder/domain/user/controller/UserController.kt
@@ -104,11 +104,13 @@ class UserController(
     @Operation(summary = "다른 사람 피드 조회하기")
     @ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
     @GetMapping("/feeds/{otherProfileId}")
-    fun getMyFeed(
+    fun getOtherPeopleFeed(
         @PathVariable otherProfileId: Long,
+        @AuthenticationPrincipal userPrincipal: UserPrincipal?,
         @PageableDefault(size = 10, sort = ["updatedAt"]) pageable: Pageable
     ): ResponseEntity<OtherPeopleFeedsResponse> {
-        return ResponseEntity.status(HttpStatus.OK).body(profileService.getOtherPeopleFeed(otherProfileId, pageable))
+        val userId = userPrincipal?.id
+        return ResponseEntity.status(HttpStatus.OK).body(profileService.getOtherPeopleFeed(otherProfileId, pageable, userId))
     }
 
     @Operation(summary = "내 활동 조회하기")

--- a/src/main/kotlin/com/eatsfinder/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/eatsfinder/domain/user/repository/UserRepository.kt
@@ -11,6 +11,8 @@ interface UserRepository : JpaRepository<User, Long> {
 
     fun findByIdAndDeletedAt(id: Long, deletedAt: LocalDateTime?): User?
 
+    fun findUserByIdAndDeletedAt(id: Long?, deletedAt: LocalDateTime?): User?
+
     fun findByEmailAndDeletedAtAndProvider(email: String, deletedAt: LocalDateTime?, provider: SocialType): User?
 
     fun findFirstByEmailOrNicknameAndProvider(email: String, nickname: String, provider: SocialType): User?

--- a/src/main/kotlin/com/eatsfinder/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/eatsfinder/domain/user/service/UserService.kt
@@ -34,7 +34,7 @@ interface UserService {
     fun getMyFeed(myProfileId: Long, pageable: Pageable) : MyFeedsResponse
 
 
-    fun getOtherPeopleFeed(otherProfileId: Long, pageable: Pageable) : OtherPeopleFeedsResponse
+    fun getOtherPeopleFeed(otherProfileId: Long, pageable: Pageable, userId: Long?) : OtherPeopleFeedsResponse
 
     fun getMyActive(myProfileId: Long, pageable: Pageable, filter : MyActiveFilter): List<MyActiveResponse>
 }

--- a/src/main/kotlin/com/eatsfinder/domain/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/eatsfinder/domain/user/service/UserServiceImpl.kt
@@ -213,29 +213,23 @@ class UserServiceImpl(
         return MyFeedsResponse.from(post!!, pageable)
     }
 
-    override fun getOtherPeopleFeed(otherProfileId: Long, pageable: Pageable): OtherPeopleFeedsResponse {
-        val profile = userRepository.findByIdAndDeletedAt(otherProfileId, null) ?: throw ModelNotFoundException(
-            "user",
-            "이 프로필은(id: ${otherProfileId})은 존재하지 않습니다."
-        )
+    override fun getOtherPeopleFeed(otherProfileId: Long, pageable: Pageable, userId: Long?): OtherPeopleFeedsResponse {
+        val profile = userRepository.findByIdAndDeletedAt(otherProfileId, null)
+            ?: throw ModelNotFoundException("user", "이 프로필은(id: ${otherProfileId})은 존재하지 않습니다.")
 
-        val userPrincipal = SecurityContextHolder.getContext().authentication?.principal as? UserPrincipal
+        val user = userId?.let { userRepository.findUserByIdAndDeletedAt(it, null) }
 
-        if (userPrincipal != null && profile.id == userPrincipal.id) {
+        if (user != null && profile.id == user.id) {
             throw MyProfileException("본인 피드이므로 조회할 수 없습니다.")
         }
 
-        val user = userRepository.findByIdAndDeletedAt(userPrincipal?.id!!, null) ?: throw ModelNotFoundException(
-            "user",
-            "이 프로필은(id: ${userPrincipal.id})은 존재하지 않습니다."
-        )
-
         val otherPost = postRepository.findByUserId(profile) ?: emptyList()
 
-        val posts = otherPost.filterNot {
-            reportPostRepository.existsByPostIdAndUserId(it, user)
+        val posts = if (user != null) {
+            otherPost.filterNot { reportPostRepository.existsByPostIdAndUserId(it, user) }
+        } else {
+            otherPost
         }
-
 
         return OtherPeopleFeedsResponse.from(posts, pageable)
     }


### PR DESCRIPTION
## 💡 PULL REQUEST

## #️⃣ 연관된 이슈

> #85 

## 📝 작업 내용

> 다른 사람의 피드를 보는 API 에서 로그인 한 기준으로 신고한 게시물은 제외되도록 새롭게 로직을 짠 후,  토큰이 없는 유저들의 조회하는 부분이 토큰이 없어서 조회할 수 없는 문제가 생겨  급하게 수정해보았다.
 