### PR TITLE
🚀 Deploy: jdk 이미지 변경

### DIFF
--- a/Dockerfile.kotlin
+++ b/Dockerfile.kotlin
@@ -6,7 +6,7 @@ COPY src src
 RUN chmod +x gradlew
 RUN ./gradlew clean build
 
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## 💡 PULL REQUEST

## #️⃣ 연관된 이슈

> #159 

## 📝 작업 내용

> #159 배포에서 openjdk:21-jdk-slim 가 없어져 이미지 변경

## 🖼️ 스크린샷 (선택)

> 
<img width="1292" height="163" alt="image" src="https://github.com/user-attachments/assets/07e3da6e-5941-4aad-ad83-29ef01b747fe" />
